### PR TITLE
Fix issue #13 (multibyte strings)

### DIFF
--- a/Crypto.php
+++ b/Crypto.php
@@ -595,7 +595,9 @@ class Crypto
     {
         if (function_exists('mb_substr'))
         {
-            return mb_substr($str, $start, $length = NULL, '8bit');
+            // mb_substr($str, 0, null, '8bit') returns an empty string on PHP 5.3
+            isset($length) OR $length = ($start >= 0 ? self::strlen($str) - $start : -$start);
+            return mb_substr($str, $start, $length, '8bit');
         }
 
         // Unlike mb_substr(), substr() doesn't accept NULL for length


### PR DESCRIPTION
Quoting the issue description:

> Do they affect us? There are $string[$index] stuff going on in this code, so maybe it could?

Yes, you are affected, given that `mbstring.func_overload` is enabled in php.ini and a multibyte chacater set is used. If that condition is present, then `strlen()`, `substr()` (and a few other string functions) are effectively replaced by their `mb_*()` equivalents, using the mbstring character set.

This patch fixes the issue.

Note: There's no point in checking for `substr(...) === FALSE`, as FALSE is only returned if you pass parameters that are invalid (such as an array for the input string), but I recall you giving me the opposite advice, so I've left that out until you convince yourself. :)
