### PR TITLE
Ensure that openssl_decrypt is available instead of openssl_encrypt

### DIFF
--- a/src/Crypto.php
+++ b/src/Crypto.php
@@ -284,7 +284,7 @@ final class Crypto
         $method = self::CIPHER.'-'.self::CIPHER_MODE;
 
         self::ensureConstantExists("OPENSSL_RAW_DATA");
-        self::ensureFunctionExists("openssl_encrypt");
+        self::ensureFunctionExists("openssl_decrypt");
         $plaintext = \openssl_decrypt(
             $ciphertext,
             $method,


### PR DESCRIPTION
In the `plainDecrypt` method we actually are ensuring that the method `openssl_encrypt` is available but what we use later is `openssl_decrypt`.