### PR TITLE
remove unsupported php version from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,13 @@
 language: php
 php:
+    - "7.0"
     - "5.6"
     - "5.5"
     - "5.4"
-    - "5.3"
-    - "5.2"
-# Versions below here are not installed on travis-ci
-#    - "5.1"
-#    - "5.0"
-#    - "4.4"
-#    - "4.3"
-#    - "4.2"
-#    - "4.1"
-#    - "4.0"
 
 matrix:
-  allow_failures:
-    - php: "5.3"
-    - php: "5.2"
+    fast_finish: true
+    allow_failures:
+      - php: "7.0"
 
 script: ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ php:
     - "5.5"
     - "5.4"
 
+sudo: false
+
 matrix:
     fast_finish: true
     allow_failures:


### PR DESCRIPTION
Some minor improvements for Travis.

< PHP 5.4 is not supported so no need to test this, and use sudo to speed-up the boot process.

*Please ignore the typo in the branch-name...*