### PR TITLE
Fix rethrow class member type.

### DIFF
--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -17,6 +17,9 @@ use \Defuse\Crypto\Exception as Ex;
 
 class ExceptionHandler
 {
+    /**
+     * @var \Exception
+     */
     private $rethrow = NULL;
 
     public function __construct()


### PR DESCRIPTION
Without this, IDEs (such as PHPStorm) display an error:

`The thrown object must be an instance of the Exception or Throwable.`