### PR TITLE
cleanup outdated dirs

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -51,14 +51,9 @@ if (null === $input->getArgument('path')) {
     $config
         ->finder(
             Symfony\CS\Finder\DefaultFinder::create()
-                ->in('src/')
-                ->in('other/')
-                ->in('test/')
-                ->filter(
-                  function (\SplFileInfo $file) {
-                    return strpos($file->getRelativePathname(), 'random_compat') === FALSE;
-                  }
-                )
+                ->in('src')
+                ->in('test')
+                ->exclude('vendor')
         );
 }
 


### PR DESCRIPTION
- random_compat is no longer in sourcetree
- the "other" dir was obliterated
- skip composer "vendor" instead

ps: "dist" dir does not to be excluded, as it does not contain `*.php` files

ps2:  two files need php-cs fix:

```
   1) KeyProtectedByPassword.php (single_quote)
   2) unit/EncodingTest.php (ordered_use)
```

