### PR TITLE
Remove Key::loadFromRawBytesForTestingPurposesOnlyInsecure

### DIFF
--- a/src/Key.php
+++ b/src/Key.php
@@ -81,17 +81,4 @@ final class Key
         $this->key_bytes = $bytes;
     }
 
-    /**
-     * INTERNAL USE ONLY: Constructs a Key object from a string of raw bytes.
-     *
-     * @param $bytes
-     *
-     * @return \Defuse\Crypto\Key
-     *
-     * @internal
-     */
-    public static function loadFromRawBytesForTestingPurposesOnlyInsecure($bytes)
-    {
-        return new Key($bytes);
-    }
 }

--- a/test/unit/BackwardsCompatibilityTest.php
+++ b/test/unit/BackwardsCompatibilityTest.php
@@ -6,6 +6,18 @@ use \Defuse\Crypto\Key;
 
 class BackwardsCompatibilityTest extends PHPUnit_Framework_TestCase
 {
+
+	/* helper function to create a key with raw bytes */
+	public function keyHelper($rawkey) {
+		$key = Key::createNewRandomKey();
+		$func = function ($bytes) {
+				$this->key_bytes = $bytes;
+		};
+		$helper = $func->bindTo($key,$key);
+		$helper($rawkey);
+		return $key;
+	}
+
     /**
      * @expectedException \Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
      * @expectedExceptionMessage invalid hex encoding
@@ -25,7 +37,7 @@ class BackwardsCompatibilityTest extends PHPUnit_Framework_TestCase
         /* Make it try to parse the binary as hex. */
         $plain = Crypto::decrypt(
             $cipher,
-            Key::loadFromRawBytesForTestingPurposesOnlyInsecure(
+            $this->keyHelper (
                 "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F" .
                 "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F"
             ),
@@ -52,7 +64,7 @@ class BackwardsCompatibilityTest extends PHPUnit_Framework_TestCase
         /* This time, treat the binary as binary. */
         $plain = Crypto::decrypt(
             $cipher,
-            Key::loadFromRawBytesForTestingPurposesOnlyInsecure(
+            $this->keyHelper (
                 "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F" .
                 "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F"
             ),


### PR DESCRIPTION
the function loadFromRawBytesForTestingPurposesOnlyInsecure should only be used for unit testing. 

this PR removes the internal function and uses a closure to create a Key instance with the right key material.
