### PR TITLE
Don't export test for Composer package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,3 @@
 /.travis.yml export-ignore
 /test.sh export-ignore
 /test export-ignore
-/dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 /.gitattributes export-ignore
 /.travis.yml export-ignore
+/test.sh export-ignore
+/test export-ignore
+/dist export-ignore


### PR DESCRIPTION
Downloading php-encryption via Composer takes too much time for a 232KB library. This is because tests, having 13 MB of files, are including in the package. It is very inconvenient in CI environments or for user of projects that use php-encryption, as it takes time, band-width etc..

A user of the library doesn't need theses tests.
