### PR TITLE
use raw link to gpg key

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Public Keys
 ------------
 
 The GnuPG public key used to sign releases is available in
-[dist/signingkey.asc](dist/signingkey.asc). Its fingerprint is:
+[dist/signingkey.asc](https://github.com/defuse/php-encryption/raw/master/dist/signingkey.asc). Its fingerprint is:
 
 ```
 2FA6 1D8D 99B9 2658 6BAC  3D53 385E E055 A129 1538


### PR DESCRIPTION
because github renders it as html and it messes up gpg separators

![image](https://cloud.githubusercontent.com/assets/199095/18266720/c2c43b12-7424-11e6-9a3f-3f363340b870.png)


alternative would be to rename the file to have .txt extension