### PR TITLE
Fix return type of Key::createNewRandomKey()

### DIFF
--- a/src/Key.php
+++ b/src/Key.php
@@ -14,9 +14,9 @@ final class Key
     /**
      * Creates new random key.
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws \Defuse\Crypto\Exception\EnvironmentIsBrokenException
      *
-     * @return Defuse\Crypto\Key
+     * @return \Defuse\Crypto\Key
      */
     public static function createNewRandomKey()
     {


### PR DESCRIPTION
Without a leading backslash the type is interpreted relative to the current namespace.

![bug](https://cloud.githubusercontent.com/assets/3053271/18715996/caae901c-7fe0-11e6-93ac-b100fab163f0.PNG)