### PR TITLE
Fixed a couple of php doc blocks and code exceptions which were not u…

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -42,7 +42,7 @@ final class Core
      * @param string $ctr
      * @param int    $inc
      *
-     * @throws \Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      *
      * @return string
      */
@@ -97,7 +97,7 @@ final class Core
      *
      * @param int $octets
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      *
      * @return string
      */
@@ -106,7 +106,7 @@ final class Core
         self::ensureFunctionExists('random_bytes');
         try {
             return \random_bytes($octets);
-        } catch (Exception $ex) {
+        } catch (\Exception $ex) {
             throw new Ex\EnvironmentIsBrokenException(
                 'Your system does not have a secure random number generator.'
             );
@@ -123,7 +123,7 @@ final class Core
      * @param string $info   What sort of key are we deriving?
      * @param string $salt
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      *
      * @return string
      */
@@ -186,7 +186,7 @@ final class Core
      * @param string $expected
      * @param string $given
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      *
      * @return bool
      */
@@ -223,7 +223,7 @@ final class Core
      *
      * @param string $name
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      */
     public static function ensureConstantExists($name)
     {
@@ -237,7 +237,7 @@ final class Core
      *
      * @param string $name
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      */
     public static function ensureFunctionExists($name)
     {
@@ -257,7 +257,7 @@ final class Core
      *
      * @param string $str
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      *
      * @return int
      */
@@ -285,7 +285,7 @@ final class Core
      * @param int    $start
      * @param int    $length
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      *
      * @return string
      */
@@ -320,7 +320,7 @@ final class Core
 
             $substr = \mb_substr($str, $start, $length, '8bit');
             if (Core::ourStrlen($substr) !== $length) {
-                throw new EnvironmentIsBrokenException(
+                throw new Ex\EnvironmentIsBrokenException(
                     'Your version of PHP has bug #66797. Its implementation of
                     mb_substr() is incorrect. See the details here:
                     https://bugs.php.net/bug.php?id=66797'
@@ -351,7 +351,7 @@ final class Core
      * @param int    $key_length The length of the derived key in bytes.
      * @param bool   $raw_output If true, the key is returned in raw binary format. Hex encoded otherwise.
      *
-     * @throws \Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      *
      * @return string A $key_length-byte key derived from the password and salt.
      */

--- a/src/Crypto.php
+++ b/src/Crypto.php
@@ -13,7 +13,7 @@ class Crypto
      * @param Key    $key
      * @param bool   $raw_binary
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      *
      * @return string
      */
@@ -34,7 +34,7 @@ class Crypto
      * @param string $password
      * @param bool   $raw_binary
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      *
      * @return string
      */
@@ -54,8 +54,8 @@ class Crypto
      * @param Key    $key
      * @param bool   $raw_binary
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @throws Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
+     * @throws Ex\EnvironmentIsBrokenException
+     * @throws Ex\WrongKeyOrModifiedCiphertextException
      *
      * @return string
      */
@@ -76,8 +76,8 @@ class Crypto
      * @param string $password
      * @param bool   $raw_binary
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @throws Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
+     * @throws Ex\EnvironmentIsBrokenException
+     * @throws Ex\WrongKeyOrModifiedCiphertextException
      *
      * @return string
      */
@@ -200,8 +200,8 @@ class Crypto
      * @param KeyOrPassword $secret
      * @param bool          $raw_binary
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @throws Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
+     * @throws Ex\EnvironmentIsBrokenException
+     * @throws Ex\WrongKeyOrModifiedCiphertextException
      *
      * @return string
      */

--- a/src/Encoding.php
+++ b/src/Encoding.php
@@ -14,9 +14,9 @@ final class Encoding
      * Converts a byte string to a hexadecimal string without leaking
      * information through side channels.
      *
-     * @param string $binary_string
+     * @param string $byte_string
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      *
      * @return string
      */
@@ -42,8 +42,8 @@ final class Encoding
      *
      * @param string $hex_string
      *
-     * @throws Defuse\Crypto\Exception\BadFormatException
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\BadFormatException
+     * @throws Ex\EnvironmentIsBrokenException
      *
      * @return string
      */
@@ -114,7 +114,7 @@ final class Encoding
      * @param string $header
      * @param string $bytes
      *
-     * @throws \Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      *
      * @return string
      */
@@ -146,8 +146,8 @@ final class Encoding
      * @param string $expected_header
      * @param string $string
      *
-     * @throws \Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @throws \Defuse\Crypto\Exception\BadFormatException
+     * @throws Ex\EnvironmentIsBrokenException
+     * @throws Ex\BadFormatException
      *
      * @return string
      */

--- a/src/File.php
+++ b/src/File.php
@@ -13,8 +13,8 @@ final class File
      * @param string $outputFilename
      * @param Key    $key
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @throws Defuse\Crypto\Exception\IOException
+     * @throws Ex\EnvironmentIsBrokenException
+     * @throws Ex\IOException
      */
     public static function encryptFile($inputFilename, $outputFilename, Key $key)
     {
@@ -33,8 +33,8 @@ final class File
      * @param string $outputFilename
      * @param string $password
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @throws Defuse\Crypto\Exception\IOException
+     * @throws Ex\EnvironmentIsBrokenException
+     * @throws Ex\IOException
      */
     public static function encryptFileWithPassword($inputFilename, $outputFilename, $password)
     {
@@ -52,9 +52,9 @@ final class File
      * @param string $outputFilename
      * @param Key    $key
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @throws Defuse\Crypto\Exception\IOException
-     * @throws Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
+     * @throws Ex\EnvironmentIsBrokenException
+     * @throws Ex\IOException
+     * @throws Ex\WrongKeyOrModifiedCiphertextException
      */
     public static function decryptFile($inputFilename, $outputFilename, Key $key)
     {
@@ -73,9 +73,9 @@ final class File
      * @param string $outputFilename
      * @param string $password
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @throws Defuse\Crypto\Exception\IOException
-     * @throws Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
+     * @throws Ex\EnvironmentIsBrokenException
+     * @throws Ex\IOException
+     * @throws Ex\WrongKeyOrModifiedCiphertextException
      */
     public static function decryptFileWithPassword($inputFilename, $outputFilename, $password)
     {
@@ -94,8 +94,8 @@ final class File
      * @param resource $outputHandle
      * @param Key      $key
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @throws Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
+     * @throws Ex\EnvironmentIsBrokenException
+     * @throws Ex\WrongKeyOrModifiedCiphertextException
      */
     public static function encryptResource($inputHandle, $outputHandle, Key $key)
     {
@@ -115,9 +115,9 @@ final class File
      * @param resource $outputHandle
      * @param string   $password
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @throws Defuse\Crypto\Exception\IOException
-     * @throws Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
+     * @throws Ex\EnvironmentIsBrokenException
+     * @throws Ex\IOException
+     * @throws Ex\WrongKeyOrModifiedCiphertextException
      */
     public static function encryptResourceWithPassword($inputHandle, $outputHandle, $password)
     {
@@ -136,9 +136,9 @@ final class File
      * @param resource $outputHandle
      * @param Key      $key
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @throws Defuse\Crypto\Exception\IOException
-     * @throws Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
+     * @throws Ex\EnvironmentIsBrokenException
+     * @throws Ex\IOException
+     * @throws Ex\WrongKeyOrModifiedCiphertextException
      */
     public static function decryptResource($inputHandle, $outputHandle, Key $key)
     {
@@ -157,9 +157,9 @@ final class File
      * @param resource $outputHandle
      * @param string   $password
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @throws Defuse\Crypto\Exception\IOException
-     * @throws Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
+     * @throws Ex\EnvironmentIsBrokenException
+     * @throws Ex\IOException
+     * @throws Ex\WrongKeyOrModifiedCiphertextException
      */
     public static function decryptResourceWithPassword($inputHandle, $outputHandle, $password)
     {
@@ -177,8 +177,8 @@ final class File
      * @param string        $outputFilename
      * @param KeyOrPassword $secret
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @throws Defuse\Crypto\Exception\IOException
+     * @throws Ex\CryptoException
+     * @throws Ex\IOException
      */
     private static function encryptFileInternal($inputFilename, $outputFilename, KeyOrPassword $secret)
     {
@@ -241,9 +241,8 @@ final class File
      * @param string        $outputFilename
      * @param KeyOrPassword $secret
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @throws Defuse\Crypto\Exception\IOException
-     * @throws Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
+     * @throws Ex\CryptoException
+     * @throws Ex\IOException
      */
     private static function decryptFileInternal($inputFilename, $outputFilename, KeyOrPassword $secret)
     {
@@ -308,8 +307,8 @@ final class File
      * @param resource      $outputHandle
      * @param KeyOrPassword $secret
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @throws Defuse\Crypto\Exception\IOException
+     * @throws Ex\EnvironmentIsBrokenException
+     * @throws Ex\IOException
      */
     private static function encryptResourceInternal($inputHandle, $outputHandle, KeyOrPassword $secret)
     {
@@ -414,7 +413,7 @@ final class File
 
         /* Get the HMAC and append it to the ciphertext. */
         $final_mac = \hash_final($hmac, true);
-        self::writeBytes($outputHandle, $final_mac, CORE::MAC_BYTE_SIZE);
+        self::writeBytes($outputHandle, $final_mac, Core::MAC_BYTE_SIZE);
     }
 
     /**
@@ -424,9 +423,9 @@ final class File
      * @param resource      $outputHandle
      * @param KeyOrPassword $secret
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @throws Defuse\Crypto\Exception\IOException
-     * @throws Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
+     * @throws Ex\EnvironmentIsBrokenException
+     * @throws Ex\IOException
+     * @throws Ex\WrongKeyOrModifiedCiphertextException
      */
     public static function decryptResourceInternal($inputHandle, $outputHandle, KeyOrPassword $secret)
     {
@@ -663,8 +662,8 @@ final class File
      * @param resource $stream
      * @param int      $num_bytes
      *
-     * @throws Defuse\Crypto\Exception\IOException
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\IOException
+     * @throws Ex\EnvironmentIsBrokenException
      *
      * @return string
      */
@@ -705,7 +704,7 @@ final class File
      * @param string   $buf
      * @param int      $num_bytes
      *
-     * @throws Defuse\Crypto\Exception\IOException
+     * @throws Ex\IOException
      *
      * @return string
      */

--- a/src/Key.php
+++ b/src/Key.php
@@ -14,9 +14,9 @@ final class Key
     /**
      * Creates new random key.
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      *
-     * @return Defuse\Crypto\Key
+     * @return Key
      */
     public static function createNewRandomKey()
     {
@@ -26,10 +26,10 @@ final class Key
     /**
      * Loads a Key from its encoded form.
      *
-     * @param string $savedKeyString
+     * @param string $saved_key_string
      *
-     * @throws \Defuse\Crypto\Exception\BadFormatException
-     * @throws \Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\BadFormatException
+     * @throws Ex\EnvironmentIsBrokenException
      *
      * @return \Defuse\Crypto\Key
      */
@@ -42,7 +42,7 @@ final class Key
     /**
      * Encodes the Key into a string of printable ASCII characters.
      *
-     * @throws \Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      *
      * @return string
      */
@@ -69,7 +69,7 @@ final class Key
      *
      * @param string $bytes
      *
-     * @throws \Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      */
     private function __construct($bytes)
     {

--- a/src/KeyOrPassword.php
+++ b/src/KeyOrPassword.php
@@ -43,7 +43,7 @@ final class KeyOrPassword
      *
      * @param string $salt
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      *
      * @return DerivedKeys
      */

--- a/src/KeyProtectedByPassword.php
+++ b/src/KeyProtectedByPassword.php
@@ -15,7 +15,7 @@ final class KeyProtectedByPassword
      *
      * @param string $password
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      *
      * @return KeyProtectedByPassword
      */
@@ -40,7 +40,7 @@ final class KeyProtectedByPassword
      *
      * @param string $saved_key_string
      *
-     * @throws Defuse\Crypto\Exception\BadFormatException
+     * @throws Ex\BadFormatException
      *
      * @return KeyProtectedByPassword
      */
@@ -57,7 +57,7 @@ final class KeyProtectedByPassword
      * Encodes the KeyProtectedByPassword into a string of printable ASCII
      * characters.
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      *
      * @return string
      */
@@ -73,8 +73,8 @@ final class KeyProtectedByPassword
      * Decrypts the protected key, returning an unprotected Key object that can
      * be used for encryption and decryption.
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @throws Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
+     * @throws Ex\EnvironmentIsBrokenException
+     * @throws Ex\WrongKeyOrModifiedCiphertextException
      *
      * @return Key
      */

--- a/src/RuntimeTests.php
+++ b/src/RuntimeTests.php
@@ -16,7 +16,7 @@ class RuntimeTests extends Crypto
     /**
      * Runs the runtime tests.
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      */
     public static function runtimeTest()
     {
@@ -78,7 +78,7 @@ class RuntimeTests extends Crypto
     /**
      * High-level tests of Crypto operations.
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      */
     private static function testEncryptDecrypt()
     {
@@ -147,7 +147,7 @@ class RuntimeTests extends Crypto
     /**
      * Test HKDF against test vectors.
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      */
     private static function HKDFTestVector()
     {
@@ -185,7 +185,7 @@ class RuntimeTests extends Crypto
     /**
      * Test HMAC against test vectors.
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      */
     private static function HMACTestVector()
     {
@@ -201,7 +201,7 @@ class RuntimeTests extends Crypto
     /**
      * Test AES against test vectors.
      *
-     * @throws Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @throws Ex\EnvironmentIsBrokenException
      */
     private static function AESTestVector()
     {


### PR DESCRIPTION
…nder the good namespace.

Some IDEs go crazy about some php doc blocks.
However, fixing those I found:
- 2 places where some exceptions were not under the good namespace: Core class - [line 109](https://github.com/defuse/php-encryption/pull/301/files#diff-89d1fea6394c1d22aa87a02eca932b1cL109) and [line 323](https://github.com/defuse/php-encryption/pull/301/files#diff-89d1fea6394c1d22aa87a02eca932b1cL323).
- 1 place where the class name was not case sensitive: File class - [line 417](https://github.com/defuse/php-encryption/pull/301/files#diff-41b5ea2bbaadc935cf6b51194eba6e68L417).

Using this library on a project. Top work! :)