### PR TITLE
Don't rebuild when signing the .phar

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -8,7 +8,7 @@ composer := "composer"
 all: build-phar
 
 .PHONY: sign-phar
-sign-phar: build-phar
+sign-phar:
 	gpg -u 7B4B2D98 --armor --output defuse-crypto.phar.sig --detach-sig defuse-crypto.phar
 
 # ensure we run in clean tree. export git tree and run there.


### PR DESCRIPTION
Unfortunately this didn't make it into 2.0.2, but that's okay because it only affects the next release process (and I double checked 2.0.2 still passes tests).