### PR TITLE
Updated constraint on OpenSSL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "paragonie/random_compat": "~2.0",
-        "ext-openssl": "*",
+        "ext-openssl": ">=1.0.1",
         "php":  ">=5.4.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hi,

as AES-CTR-256 is declared as the default CIPHER METHOD and as it's only available since OpenSSL 1.0.1 I guess the requirements should be updated.

A lot of basic web providers, like OVH, 1&1 or Go daddy are still using OpenSLL 0.98 and can't enjoy by default your nice library.

Any idea on how to use this library with OpenSLL 0.98 ? We use it for PrestaShop and we want to ease the installation for final users.

Mickaël
