### PR TITLE
Strip Newlines from ASCII-Safe Strings

### DIFF
--- a/docs/classes/Key.md
+++ b/docs/classes/Key.md
@@ -74,17 +74,23 @@ None.
 
 None.
 
-### Key::loadFromAsciiSafeString($saved\_key\_string)
+### Key::loadFromAsciiSafeString($saved\_key\_string, $do\_not\_trim = false)
 
 **Description:**
 
 Loads an instance of `Key` that was saved to a string by
 `saveToAsciiSafeString()`.
 
+By default, this function will call `Encoding::trimTrailingWhitespace()`
+to remove trailing CR, LF, NUL, TAB, and SPACE characters, which are commonly
+appended to files when working with text editors.
+
 **Parameters:**
 
 1. `$saved_key_string` is the string returned from `saveToAsciiSafeString()`
    when the original `Key` instance was saved.
+2. `$do_not_trim` should be set to `TRUE` if you do not wish for the library
+   to automatically strip trailing whitespace from the string. 
 
 **Return value:**
 

--- a/src/Encoding.php
+++ b/src/Encoding.php
@@ -107,7 +107,7 @@ final class Encoding
             
             // if ($chr === 0x20) $length -= 1;
             $length -= (((0x1f - $chr) & ($chr - 0x21)) >> 8) & 1;
-        } while ($prev !== $length);
+        } while ($prev !== $length && $length >= 0);
         return Core::ourSubstr($string, 0, $length);
     }
 

--- a/src/Encoding.php
+++ b/src/Encoding.php
@@ -86,7 +86,7 @@ final class Encoding
      * @param string $string
      * @return string
      */
-    public static function rtrim($string = '')
+    public static function trimTrailingWhitespace($string = '')
     {
         $prev = $length = Core::ourStrlen($string);
         do {

--- a/src/Encoding.php
+++ b/src/Encoding.php
@@ -88,40 +88,44 @@ final class Encoding
      */
     public static function trimTrailingWhitespace($string = '')
     {
-        $prev = $length = Core::ourStrlen($string);
+        $length = Core::ourStrlen($string);
         do {
+            $prev = $length;
             $last = $length - 1;
             $chr = \ord($string[$last]);
 
+            /* Null Byte (0x00), a.k.a. \0 */
             // if ($chr === 0x00) $length -= 1;
-            $sub = (~($chr ^ 0x00)) & 1;
+            $sub = (($chr - 1) >> 8 ) & 1;
             $length -= $sub;
             $last -= $sub;
 
+            /* Horizontal Tab (0x09) a.k.a. \t */
+            $chr = \ord($string[$last]);
+            // if ($chr === 0x09) $length -= 1;
+            $sub = (((0x08 - $chr) & ($chr - 0x0a)) >> 8) & 1;
+            $length -= $sub;
+            $last -= $sub;
+
+            /* New Line (0x0a), a.k.a. \n */
             $chr = \ord($string[$last]);
             // if ($chr === 0x0a) $length -= 1;
             $sub = (((0x09 - $chr) & ($chr - 0x0b)) >> 8) & 1;
             $length -= $sub;
             $last -= $sub;
 
-            $chr = \ord($string[$last]);
-            // if ($chr === 0x0b) $length -= 1;
-            $sub = (((0x0a - $chr) & ($chr - 0x0c)) >> 8) & 1;
-            $length -= $sub;
-            $last -= $sub;
-
+            /* Carriage Return (0x0D), a.k.a. \r */
             $chr = \ord($string[$last]);
             // if ($chr === 0x0d) $length -= 1;
             $sub = (((0x0c - $chr) & ($chr - 0x0e)) >> 8) & 1;
             $length -= $sub;
             $last -= $sub;
 
+            /* Space */
             $chr = \ord($string[$last]);
             // if ($chr === 0x20) $length -= 1;
             $sub = (((0x1f - $chr) & ($chr - 0x21)) >> 8) & 1;
             $length -= $sub;
-
-            $prev = $length;
         } while ($prev !== $length && $length > 0);
         return Core::ourSubstr($string, 0, $length);
     }

--- a/src/Key.php
+++ b/src/Key.php
@@ -35,7 +35,7 @@ final class Key
      */
     public static function loadFromAsciiSafeString($saved_key_string)
     {
-        $saved_key_string = Encoding::rtrim($saved_key_string, "\r\n");
+        $saved_key_string = Encoding::trimTrailingWhitespace($saved_key_string);
         $key_bytes = Encoding::loadBytesFromChecksummedAsciiSafeString(self::KEY_CURRENT_VERSION, $saved_key_string);
         return new Key($key_bytes);
     }

--- a/src/Key.php
+++ b/src/Key.php
@@ -35,7 +35,7 @@ final class Key
      */
     public static function loadFromAsciiSafeString($saved_key_string)
     {
-        $saved_key_string = Core::rtrim($saved_key_string, "\r\n");
+        $saved_key_string = Encoding::rtrim($saved_key_string, "\r\n");
         $key_bytes = Encoding::loadBytesFromChecksummedAsciiSafeString(self::KEY_CURRENT_VERSION, $saved_key_string);
         return new Key($key_bytes);
     }

--- a/src/Key.php
+++ b/src/Key.php
@@ -35,6 +35,7 @@ final class Key
      */
     public static function loadFromAsciiSafeString($saved_key_string)
     {
+        $saved_key_string = rtrim($saved_key_string, "\r\n");
         $key_bytes = Encoding::loadBytesFromChecksummedAsciiSafeString(self::KEY_CURRENT_VERSION, $saved_key_string);
         return new Key($key_bytes);
     }

--- a/src/Key.php
+++ b/src/Key.php
@@ -27,7 +27,8 @@ final class Key
      * Loads a Key from its encoded form.
      *
      * By default, this function will call Encoding::trimTrailingWhitespace()
-     * to remove trailing CR, LF, NUL, TAB, and SPACE characters.
+     * to remove trailing CR, LF, NUL, TAB, and SPACE characters, which are
+     * commonly appended to files when working with text editors.
      *
      * @param string $saved_key_string
      * @param bool $do_not_trim (default: false)

--- a/src/Key.php
+++ b/src/Key.php
@@ -35,7 +35,7 @@ final class Key
      */
     public static function loadFromAsciiSafeString($saved_key_string)
     {
-        $saved_key_string = rtrim($saved_key_string, "\r\n");
+        $saved_key_string = Core::rtrim($saved_key_string, "\r\n");
         $key_bytes = Encoding::loadBytesFromChecksummedAsciiSafeString(self::KEY_CURRENT_VERSION, $saved_key_string);
         return new Key($key_bytes);
     }

--- a/src/Key.php
+++ b/src/Key.php
@@ -26,16 +26,22 @@ final class Key
     /**
      * Loads a Key from its encoded form.
      *
+     * By default, this function will call Encoding::trimTrailingWhitespace()
+     * to remove trailing CR, LF, NUL, TAB, and SPACE characters.
+     *
      * @param string $saved_key_string
+     * @param bool $do_not_trim (default: false)
      *
      * @throws Ex\BadFormatException
      * @throws Ex\EnvironmentIsBrokenException
      *
      * @return Key
      */
-    public static function loadFromAsciiSafeString($saved_key_string)
+    public static function loadFromAsciiSafeString($saved_key_string, $do_not_trim = false)
     {
-        $saved_key_string = Encoding::trimTrailingWhitespace($saved_key_string);
+        if (!$do_not_trim) {
+            $saved_key_string = Encoding::trimTrailingWhitespace($saved_key_string);
+        }
         $key_bytes = Encoding::loadBytesFromChecksummedAsciiSafeString(self::KEY_CURRENT_VERSION, $saved_key_string);
         return new Key($key_bytes);
     }

--- a/test/unit/EncodingTest.php
+++ b/test/unit/EncodingTest.php
@@ -97,21 +97,6 @@ class EncodingTest extends PHPUnit_Framework_TestCase
             Core::secureRandom(Core::KEY_BYTE_SIZE)
         );
         $orig = $str;
-
-        $str .= "\r";
-        Encoding::loadBytesFromChecksummedAsciiSafeString($header, $str);
-
-        $str .= "\n";
-        Encoding::loadBytesFromChecksummedAsciiSafeString($header, $str);
-
-        $str .= "\t";
-        Encoding::loadBytesFromChecksummedAsciiSafeString($header, $str);
-
-        $str .= "\0";
-        Encoding::loadBytesFromChecksummedAsciiSafeString($header, $str);
-
-        $str = $orig;
-
         $noise = ["\r", "\n", "\t", "\0"];
         for ($i = 0; $i < 1000; ++$i) {
             $c = $noise[\random_int(0, 3)];

--- a/test/unit/EncodingTest.php
+++ b/test/unit/EncodingTest.php
@@ -93,7 +93,31 @@ class EncodingTest extends PHPUnit_Framework_TestCase
             $header,
             Core::secureRandom(Core::KEY_BYTE_SIZE)
         );
+        $orig = $str;
+
+        $str .= "\r";
+        Encoding::loadBytesFromChecksummedAsciiSafeString($header, $str);
+
         $str .= "\n";
         Encoding::loadBytesFromChecksummedAsciiSafeString($header, $str);
+
+        $str .= "\t";
+        Encoding::loadBytesFromChecksummedAsciiSafeString($header, $str);
+
+        $str .= "\0";
+        Encoding::loadBytesFromChecksummedAsciiSafeString($header, $str);
+
+        $str = $orig;
+
+        $noise = ["\r", "\n", "\t", "\0"];
+        for ($i = 0; $i < 1000; ++$i) {
+            $c = $noise[\random_int(0, 3)];
+            $str .= $c;
+            $this->assertSame(
+                Encoding::binToHex($orig),
+                Encoding::binToHex(Encoding::trimTrailingWhitespace($str)),
+                'Pass #' . $i . ' (' . \dechex(\ord($c)) . ')'
+            );
+        }
     }
 }

--- a/test/unit/EncodingTest.php
+++ b/test/unit/EncodingTest.php
@@ -82,4 +82,18 @@ class EncodingTest extends PHPUnit_Framework_TestCase
         $str[0] = 'Z';
         Encoding::loadBytesFromChecksummedAsciiSafeString($header, $str);
     }
+
+    /**
+     * This shouldn't throw an exception.
+     */
+    public function testPaddedHexEncoding()
+    {
+        $header = Core::secureRandom(Core::HEADER_VERSION_SIZE);
+        $str = Encoding::saveBytesToChecksummedAsciiSafeString(
+            $header,
+            Core::secureRandom(Core::KEY_BYTE_SIZE)
+        );
+        $str .= "\n";
+        Encoding::loadBytesFromChecksummedAsciiSafeString($header, $str);
+    }
 }

--- a/test/unit/EncodingTest.php
+++ b/test/unit/EncodingTest.php
@@ -88,6 +88,9 @@ class EncodingTest extends PHPUnit_Framework_TestCase
      */
     public function testPaddedHexEncoding()
     {
+        /* We're just ensuring that an empty string doesn't produce an error. */
+        $this->assertSame('', Encoding::trimTrailingWhitespace(''));
+
         $header = Core::secureRandom(Core::HEADER_VERSION_SIZE);
         $str = Encoding::saveBytesToChecksummedAsciiSafeString(
             $header,


### PR DESCRIPTION
This would prevent the errors present in #333 and #334. I don't believe removing newlines in variable time would ever introduce a practical timing leak, but I'll wait until @defuse sanity-checks this.