### PR TITLE
Allow hash_* methods to return a object to support PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       env: USE_PSALM=1
     - php: "7.1"
       env: USE_PSALM=1
+    - php: "7.2"
+      env: USE_PSALM=1
     - php: "nightly"
       env: USE_PSALM=1
     - php: "hhvm"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "defuse/php-encryption",
+    "name": "enflow-nl/php-encryption",
     "description": "Secure PHP Encryption Library",
     "license": "MIT",
     "keywords": ["security", "encryption", "AES", "openssl", "cipher", "cryptography", "symmetric key cryptography", "crypto", "encrypt", "authenticated encryption"],

--- a/src/File.php
+++ b/src/File.php
@@ -348,7 +348,7 @@ final class File
         /* Initialize a streaming HMAC state. */
         /** @var resource $hmac */
         $hmac = \hash_init(Core::HASH_FUNCTION_NAME, HASH_HMAC, $akey);
-        if (!\is_resource($hmac)) {
+        if (!\is_resource($hmac) && !\is_object($hmac)) {
             throw new Ex\EnvironmentIsBrokenException(
                 'Cannot initialize a hash context'
             );
@@ -518,7 +518,7 @@ final class File
         /* Initialize a streaming HMAC state. */
         /** @var resource $hmac */
         $hmac = \hash_init(Core::HASH_FUNCTION_NAME, HASH_HMAC, $akey);
-        if (!\is_resource($hmac)) {
+        if (!\is_resource($hmac) && !\is_object($hmac)) {
             throw new Ex\EnvironmentIsBrokenException(
                 'Cannot initialize a hash context'
             );
@@ -576,7 +576,7 @@ final class File
             /* Remember this buffer-sized chunk's HMAC. */
             /** @var resource $chunk_mac */
             $chunk_mac = \hash_copy($hmac);
-            if (!\is_resource($chunk_mac)) {
+            if (!\is_resource($chunk_mac) && !\is_object($chunk_mac)) {
                 throw new Ex\EnvironmentIsBrokenException(
                     'Cannot duplicate a hash context'
                 );
@@ -634,7 +634,7 @@ final class File
             \hash_update($hmac2, $read);
             /** @var resource $calc_mac */
             $calc_mac = \hash_copy($hmac2);
-            if (!\is_resource($calc_mac)) {
+            if (!\is_resource($calc_mac) && !\is_object($calc_mac)) {
                 throw new Ex\EnvironmentIsBrokenException(
                     'Cannot duplicate a hash context'
                 );


### PR DESCRIPTION
See #374 for more info regarding this issue. Test suite passed on a PHP 7.2 env.