### PR TITLE
Allow random_compat v9.99.99 on PHP 7 projects.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "paragonie/random_compat": "~2.0",
+        "paragonie/random_compat": ">= 2",
         "ext-openssl": "*",
         "php":  ">=5.4.0"
     },

--- a/psalm.xml
+++ b/psalm.xml
@@ -7,6 +7,7 @@
     </projectFiles>
     <issueHandlers>
         <DocblockTypeContradiction errorLevel="info" />
+        <RedundantCondition errorLevel="info" />
         <RedundantConditionGivenDocblockType errorLevel="info" />
     </issueHandlers>
 </psalm>

--- a/src/Encoding.php
+++ b/src/Encoding.php
@@ -46,6 +46,7 @@ final class Encoding
      * @throws Ex\EnvironmentIsBrokenException
      *
      * @return string
+     * @psalm-suppress TypeDoesNotContainType
      */
     public static function hexToBin($hex_string)
     {


### PR DESCRIPTION
For PHP 7+ software, we have a special tag at `v9.99.99` which is essentially empty. The purpose of this tag is to allow it to be loaded by Composer for PHP 7 software, and then not create conflicting definitions for static analysis tools and/or IDEs' type hinting.

See https://twitter.com/CiPHPerCoder/status/1004230888169852928