### PR TITLE
Make Phar builds reproducible

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -2,7 +2,8 @@
 # must be installed and in your $PATH. Run it from inside the dist/ directory.
 
 box := $(shell which box)
-composer := "composer"
+composer := $(shell which composer)
+gitcommit := $(shell git rev-parse HEAD)
 
 .PHONY: all
 all: build-phar

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -33,5 +33,6 @@ defuse-crypto.phar: dist/box.json composer.lock
 	php -d phar.readonly=0 $(box) build -c box.json -v
 
 composer.lock:
+	$(composer) config autoloader-suffix $(gitcommit)
 	$(composer) install --no-dev
 


### PR DESCRIPTION
This will make PHP Archive builds reproducible from the source code by eliminating nondeterminism via Composer's autoloader nonce.