### PR TITLE
Add message to some exceptions

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -228,7 +228,10 @@ final class Core
      */
     public static function ensureConstantExists($name)
     {
-        Core::ensureTrue(\defined($name));
+        Core::ensureTrue(
+            \defined($name),
+            'Constant '.$name.' does not exists'
+        );
     }
 
     /**
@@ -241,7 +244,10 @@ final class Core
      */
     public static function ensureFunctionExists($name)
     {
-        Core::ensureTrue(\function_exists($name));
+        Core::ensureTrue(
+            \function_exists($name),
+            'function '.$name.' does not exists'
+        );
     }
 
     /**


### PR DESCRIPTION
It is hard to diagnose the fail of some API, when the exception does not
contain a message. Having the reason of the fail, especially when a function or
a constant is missing, helps to fix an environment issue for example.