### PR TITLE
Add option to speed up the tests. Fix #400

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to the code
+
+## Running the syntax fixer
+
+```bash
+./vendor/bin/php-cs-fixer fix
+```
+
+## Running the unit tests
+
+```bash
+./test.sh
+```
+
+To skip time-consuming tests:
+
+```bash
+./test.sh 0 fast
+```

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@ if [ ! -e $BIG_GENERATED_FILE ] || [ $(wc -c < $BIG_GENERATED_FILE) -ne "2097152
     dd if=/dev/urandom "of=$BIG_GENERATED_FILE" bs=1M count=200
 fi
 
-if [ -n "$1" ]; then
+if [ -f "$1" ]; then
     BOOTSTRAP="$1"
     MEASURECOVERAGE="0"
 else
@@ -16,9 +16,15 @@ else
     MEASURECOVERAGE="1"
 fi
 
+if [ "$2" == "fast" ]; then
+    EXCLUDE_SLOW="1"
+else
+    EXCLUDE_SLOW="0"
+fi
+
 # loading bootstrap should output nothing
 load=$(php -r "require '$BOOTSTRAP';")
 test -z "$load"
 
-./test/phpunit.sh "$BOOTSTRAP" "$MEASURECOVERAGE"
+./test/phpunit.sh "$BOOTSTRAP" "$MEASURECOVERAGE" "$EXCLUDE_SLOW"
 echo ""

--- a/test/phpunit.sh
+++ b/test/phpunit.sh
@@ -3,10 +3,10 @@
 # This was written by Scott Arciszewski. I copied it from his Halite project:
 # https://github.com/paragonie/halite
 
-origdir=`pwd`
-cdir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-cd $origdir
-parentdir="$(dirname $cdir)"
+origdir=$(pwd)
+cdir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+cd "$origdir" || exit
+parentdir="$(dirname "$cdir")"
 PHP_VERSION=$(php -r "echo PHP_VERSION_ID;");
 
 clean=0 # Clean up?
@@ -62,11 +62,19 @@ if [ $? -eq 0 ]; then
         COVERAGE1_ARGS=""
         COVERAGE2_ARGS=""
     fi
+
+    # switch for excluding slow tests
+    if [ "$3" -eq "1" ]; then
+        EXCLUDE_SLOW="--exclude-group slow"
+    else
+        EXCLUDE_SLOW=""
+    fi
+
     echo -e "\033[33mBegin Unit Testing\033[0m"
     # Run the test suite with normal func_overload.
-    php -d mbstring.func_overload=0 phpunit.phar $COVERAGE1_ARGS --bootstrap "$parentdir/$1" "$parentdir/test/unit" && \
+    php -d mbstring.func_overload=0 phpunit.phar $COVERAGE1_ARGS $EXCLUDE_SLOW --bootstrap "$parentdir/$1" "$parentdir/test/unit" && \
     # Run the test suite again with funky func_overload.
-    php -d mbstring.func_overload=7 phpunit.phar $COVERAGE2_ARGS --bootstrap "$parentdir/$1"  "$parentdir/test/unit"
+    php -d mbstring.func_overload=7 phpunit.phar $COVERAGE2_ARGS $EXCLUDE_SLOW --bootstrap "$parentdir/$1"  "$parentdir/test/unit"
     EXITCODE=$?
     # Cleanup
     if [ "$clean" -eq 1 ]; then

--- a/test/unit/CtrModeTest.php
+++ b/test/unit/CtrModeTest.php
@@ -139,7 +139,6 @@ class CtrModeTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @group slow
      */
     public function testIncrementByZero()
     {
@@ -161,7 +160,6 @@ class CtrModeTest extends PHPUnit_Framework_TestCase
     /**
      * @dataProvider allNonZeroByteValuesProvider
      * @expectedException \Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @group slow
      */
     public function testIncrementCausingOverflowInFirstByte($lsb)
     {
@@ -173,7 +171,6 @@ class CtrModeTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @group slow
      */
     public function testIncrementWithShortIvLength()
     {
@@ -185,7 +182,6 @@ class CtrModeTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @group slow
      */
     public function testIncrementWithLongIvLength()
     {
@@ -197,7 +193,6 @@ class CtrModeTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     * @group slow
      */
     public function testIncrementByNonInteger()
     {

--- a/test/unit/CtrModeTest.php
+++ b/test/unit/CtrModeTest.php
@@ -139,6 +139,7 @@ class CtrModeTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @group slow
      */
     public function testIncrementByZero()
     {
@@ -160,6 +161,7 @@ class CtrModeTest extends PHPUnit_Framework_TestCase
     /**
      * @dataProvider allNonZeroByteValuesProvider
      * @expectedException \Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @group slow
      */
     public function testIncrementCausingOverflowInFirstByte($lsb)
     {
@@ -171,6 +173,7 @@ class CtrModeTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @group slow
      */
     public function testIncrementWithShortIvLength()
     {
@@ -182,6 +185,7 @@ class CtrModeTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @group slow
      */
     public function testIncrementWithLongIvLength()
     {
@@ -193,6 +197,7 @@ class CtrModeTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Defuse\Crypto\Exception\EnvironmentIsBrokenException
+     * @group slow
      */
     public function testIncrementByNonInteger()
     {
@@ -202,6 +207,9 @@ class CtrModeTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @group slow
+     */
     public function testCompatibilityWithOpenSSL()
     {
         /* Plaintext is 0x300 blocks. */

--- a/test/unit/EncodingTest.php
+++ b/test/unit/EncodingTest.php
@@ -5,6 +5,9 @@ use \Defuse\Crypto\Core;
 
 class EncodingTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @group slow
+     */
     public function testEncodeDecodeEquivalency()
     {
         for ($length = 0; $length < 50; $length++) {
@@ -49,6 +52,7 @@ class EncodingTest extends PHPUnit_Framework_TestCase
     /**
      * @expectedException \Defuse\Crypto\Exception\BadFormatException
      * @expectedExceptionMessage checksum doesn't match
+     * @group slow
      */
     public function testIncorrectChecksum()
     {
@@ -71,6 +75,7 @@ class EncodingTest extends PHPUnit_Framework_TestCase
     /**
      * @expectedException \Defuse\Crypto\Exception\BadFormatException
      * @expectedExceptionMessage not a hex string
+     * @group slow
      */
     public function testBadHexEncoding()
     {

--- a/test/unit/FileTest.php
+++ b/test/unit/FileTest.php
@@ -29,6 +29,7 @@ class FileTest extends \PHPUnit_Framework_TestCase
      * Test encryption from one file name to a destination file name
      *
      * @dataProvider fileToFileProvider
+     * @group slow
      *
      * @param string $srcName source file name
      */
@@ -63,6 +64,7 @@ class FileTest extends \PHPUnit_Framework_TestCase
      * Test encryption from one file name to a destination file name (password).
      *
      * @dataProvider fileToFileProvider
+     * @group slow
      *
      * @param string $srcName source file name
      */
@@ -95,6 +97,7 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider fileToFileProvider
+     * @group slow
      *
      * @param string $src source handle
      */


### PR DESCRIPTION
* Check if first argument of `test.sh` is a file instead of its
existence
* Add "fast" argument to skip test in "@group slow"
* Small fixes to the bash scripts (quotes, syntax, failsafe)
* Add CONTRIBUTING.md file with instructions for tests and syntax fixing

On my 4 GHz CPU, this brings the tests from 109 seconds down to 63
seconds.