### PR TITLE
Fix for PHP 8 + Opcache with error "Invalid opcode 117/2/0." 

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -405,7 +405,7 @@ final class Core
 
         $algorithm = \strtolower($algorithm);
         Core::ensureTrue(
-            \in_array($algorithm, \hash_algos(), true),
+            in_array($algorithm, \hash_algos(), true),
             'Invalid or unsupported hash algorithm.'
         );
 
@@ -415,7 +415,7 @@ final class Core
             'ripemd160', 'ripemd256', 'ripemd320', 'whirlpool',
         ];
         Core::ensureTrue(
-            \in_array($algorithm, $ok_algorithms, true),
+            in_array($algorithm, $ok_algorithms, true),
             'Algorithm is not a secure cryptographic hash function.'
         );
 


### PR DESCRIPTION
This PR corrects issue #466 when running PHP 8 + Opcache