### PR TITLE
Normalise Licence file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Taylor Hornby <https://defuse.ca> and Paragon Initiative
-Enterprises <https://paragonie.com>.
+Copyright (c) 2016 Taylor Hornby <https://defuse.ca>
+Copyright (c) 2016 Paragon Initiative Enterprises <https://paragonie.com>.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
Github doesn't pick this up as MIT, made some minor changes for it to be identified correctly