### PR TITLE
Made PHPUnit tests pass in PHP 8.0, PHP 8.1 and PHP 8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ matrix:
       env: USE_PSALM=1
     - php: "8.0"
       env: USE_PSALM=1
+    - php: "8.1"
+      env: USE_PSALM=1
+    - php: "8.2"
+      env: USE_PSALM=1
     - php: "nightly"
       env: USE_PSALM=1
     - php: "hhvm"
@@ -25,7 +29,6 @@ matrix:
   allow_failures:
     - php: "nightly"
     - php: "hhvm"
-    - php: "8.0"
 install:
     - composer install
     - curl -LSs https://box-project.github.io/box2/installer.php | php

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "php":  ">=5.6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4|^5|^6|^7|^8|^9"
+        "phpunit/phpunit": "^5|^6|^7|^8|^9|^10",
+        "yoast/phpunit-polyfills": "^2.0.0"
     },
     "bin": [
         "bin/generate-defuse-key"

--- a/test/phpunit-10.xml
+++ b/test/phpunit-10.xml
@@ -1,0 +1,9 @@
+<phpunit>
+    <source>
+        <include>
+            <directory suffix=".php">../src</directory>
+        </include>
+    </source>
+    <coverage includeUncoveredFiles="true">
+    </coverage>
+</phpunit>

--- a/test/phpunit-5.xml
+++ b/test/phpunit-5.xml
@@ -1,0 +1,7 @@
+<phpunit>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">../src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/test/phpunit-8.xml
+++ b/test/phpunit-8.xml
@@ -1,0 +1,7 @@
+<phpunit>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">../src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -1,7 +1,0 @@
-<phpunit>
-<filter>
-    <whitelist processUncoveredFilesFromWhitelist="true">
-        <directory suffix=".php">../src</directory>
-    </whitelist>
-</filter>
-</phpunit>

--- a/test/unit/BackwardsCompatibilityTest.php
+++ b/test/unit/BackwardsCompatibilityTest.php
@@ -3,25 +3,22 @@
 use \Defuse\Crypto\Crypto;
 use \Defuse\Crypto\Encoding;
 use \Defuse\Crypto\Key;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
-class BackwardsCompatibilityTest extends PHPUnit_Framework_TestCase
+class BackwardsCompatibilityTest extends TestCase
 {
 
-	/* helper function to create a key with raw bytes */
-	public function keyHelper($rawkey) {
-		$key = Key::createNewRandomKey();
-		$func = function ($bytes) {
-				$this->key_bytes = $bytes;
-		};
-		$helper = $func->bindTo($key,$key);
-		$helper($rawkey);
-		return $key;
-	}
+    /* helper function to create a key with raw bytes */
+    public function keyHelper($rawkey) {
+        $key = Key::createNewRandomKey();
+        $func = function ($bytes) {
+                $this->key_bytes = $bytes;
+        };
+        $helper = $func->bindTo($key,$key);
+        $helper($rawkey);
+        return $key;
+    }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
-     * @expectedExceptionMessage invalid hex encoding
-     */
     public function testDecryptLegacyWithWrongMethodStraightUpHex()
     {
         $cipher = Encoding::hexToBin(
@@ -34,6 +31,9 @@ class BackwardsCompatibilityTest extends PHPUnit_Framework_TestCase
             '00000000000000000000000000000000'
         );
 
+        $this->expectException(\Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException::class);
+        $this->expectExceptionMessage('invalid hex encoding');
+
         /* Make it try to parse the binary as hex. */
         $plain = Crypto::decrypt(
             $cipher,
@@ -45,10 +45,6 @@ class BackwardsCompatibilityTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
-     * @expectedExceptionMessage Bad version header
-     */
     public function testDecryptLegacyWithWrongMethodStraightUpBinary()
     {
         $cipher = Encoding::hexToBin(
@@ -60,6 +56,9 @@ class BackwardsCompatibilityTest extends PHPUnit_Framework_TestCase
             /* Make it longer than the minimum length. */
             '00000000000000000000000000000000'
         );
+
+        $this->expectException(\Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException::class);
+        $this->expectExceptionMessage('Bad version header');
 
         /* This time, treat the binary as binary. */
         $plain = Crypto::decrypt(

--- a/test/unit/CoreTest.php
+++ b/test/unit/CoreTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use \Defuse\Crypto\Core;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
-class CoreTest extends PHPUnit_Framework_TestCase
+class CoreTest extends TestCase
 {
     // The specific bug the following two tests check for did not fail when
     // mbstring.func_overload=0 so it is crucial to run these tests with
@@ -111,11 +112,9 @@ class CoreTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testOurSubstrNegativeLength()
     {
+        $this->expectException(\InvalidArgumentException::class);
         Core::ourSubstr('abc', 0, -1);
     }
 

--- a/test/unit/CryptoTest.php
+++ b/test/unit/CryptoTest.php
@@ -3,9 +3,10 @@
 use \Defuse\Crypto\Core;
 use \Defuse\Crypto\Crypto;
 use \Defuse\Crypto\Key;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 use Defuse\Crypto\Exception as Ex;
 
-class CryptoTest extends PHPUnit_Framework_TestCase
+class CryptoTest extends TestCase
 {
     # Test for issue #165 -- encrypting then decrypting empty string fails.
     public function testEmptyString()
@@ -23,6 +24,7 @@ class CryptoTest extends PHPUnit_Framework_TestCase
     // We can't runtime-test the password stuff because it runs PBKDF2.
     public function testEncryptDecryptWithPassword()
     {
+        $this->expectNotToPerformAssertions();
         $data = "EnCrYpT EvErYThInG\x00\x00";
         $password = 'password';
 
@@ -93,137 +95,105 @@ class CryptoTest extends PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
-     */
     public function testDecryptRawAsHex()
     {
         $ciphertext = Crypto::encryptWithPassword('testdata', 'password', true);
+        $this->expectException(\Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException::class);
         Crypto::decryptWithPassword($ciphertext, 'password', false);
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
-     */
     public function testDecryptHexAsRaw()
     {
         $ciphertext = Crypto::encryptWithPassword('testdata', 'password', false);
+        $this->expectException(\Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException::class);
         Crypto::decryptWithPassword($ciphertext, 'password', true);
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testEncryptTypeErrorA()
     {
         $key = Key::createNewRandomKey();
+        $this->expectException(\TypeError::class);
         Crypto::encrypt(3, $key, false);
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testEncryptTypeErrorB()
     {
+        $this->expectException(\TypeError::class);
         Crypto::encrypt("plaintext", 3, false);
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testEncryptTypeErrorC()
     {
         $key = Key::createNewRandomKey();
+        $this->expectException(\TypeError::class);
         Crypto::encrypt("plaintext", $key, 3);
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testEncryptWithPasswordTypeErrorA()
     {
+        $this->expectException(\TypeError::class);
         Crypto::encryptWithPassword(3, "password", false);
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testEncryptWithPasswordTypeErrorB()
     {
+        $this->expectException(\TypeError::class);
         Crypto::encryptWithPassword("plaintext", 3, false);
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testEncryptWithPasswordTypeErrorC()
     {
+        $this->expectException(\TypeError::class);
         Crypto::encryptWithPassword("plaintext", "password", 3);
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testDecryptTypeErrorA()
     {
         $key = Key::createNewRandomKey();
+        $this->expectException(\TypeError::class);
         Crypto::decrypt(3, $key, false);
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testDecryptTypeErrorB()
     {
+        $this->expectException(\TypeError::class);
         Crypto::decrypt("ciphertext", 3, false);
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testDecryptTypeErrorC()
     {
         $key = Key::createNewRandomKey();
+        $this->expectException(\TypeError::class);
         Crypto::decrypt("ciphertext", $key, 3);
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testDecryptWithPasswordTypeErrorA()
     {
+        $this->expectException(\TypeError::class);
         Crypto::decryptWithPassword(3, "password", false);
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testDecryptWithPasswordTypeErrorB()
     {
+        $this->expectException(\TypeError::class);
         Crypto::decryptWithPassword("ciphertext", 3, false);
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testDecryptWithPasswordTypeErrorC()
     {
+        $this->expectException(\TypeError::class);
         Crypto::decryptWithPassword("ciphertext", "password", 3);
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testLegacyDecryptTypeErrorA()
     {
+        $this->expectException(\TypeError::class);
         Crypto::legacyDecrypt(3, "key");
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testLegacyDecryptTypeErrorB()
     {
+        $this->expectException(\TypeError::class);
         Crypto::legacyDecrypt("ciphertext", 3);
     }
 

--- a/test/unit/CtrModeTest.php
+++ b/test/unit/CtrModeTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use \Defuse\Crypto\Core;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
-class CtrModeTest extends PHPUnit_Framework_TestCase
+class CtrModeTest extends TestCase
 {
-    public function counterTestVectorProvider()
+    public static function counterTestVectorProvider()
     {
         return [
             /* First byte, no overflow. */
@@ -126,29 +127,25 @@ class CtrModeTest extends PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     */
     public function testIncrementByNegativeValue()
     {
+        $this->expectException(\Defuse\Crypto\Exception\EnvironmentIsBrokenException::class);
         \Defuse\Crypto\Core::incrementCounter(
             str_repeat("\x00", 16),
             -1
         );
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     */
     public function testIncrementByZero()
     {
+        $this->expectException(\Defuse\Crypto\Exception\EnvironmentIsBrokenException::class);
         \Defuse\Crypto\Core::incrementCounter(
             str_repeat("\x00", 16),
             0
         );
     }
 
-    public function allNonZeroByteValuesProvider()
+    public static function allNonZeroByteValuesProvider()
     {
         $all_bytes = [];
         for ($i = 1; $i <= 0xff; $i++) {
@@ -159,43 +156,37 @@ class CtrModeTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider allNonZeroByteValuesProvider
-     * @expectedException \Defuse\Crypto\Exception\EnvironmentIsBrokenException
      */
     public function testIncrementCausingOverflowInFirstByte($lsb)
     {
         /* Smallest value that will overflow. */
         $increment = (PHP_INT_MAX - $lsb) + 1;
         $start     = str_repeat("\x00", 15) . chr($lsb);
+        $this->expectException(\Defuse\Crypto\Exception\EnvironmentIsBrokenException::class);
         \Defuse\Crypto\Core::incrementCounter($start, $increment);
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     */
     public function testIncrementWithShortIvLength()
     {
+        $this->expectException(\Defuse\Crypto\Exception\EnvironmentIsBrokenException::class);
         \Defuse\Crypto\Core::incrementCounter(
             str_repeat("\x00", 15),
             1
         );
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     */
     public function testIncrementWithLongIvLength()
     {
+        $this->expectException(\Defuse\Crypto\Exception\EnvironmentIsBrokenException::class);
         \Defuse\Crypto\Core::incrementCounter(
             str_repeat("\x00", 17),
             1
         );
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\EnvironmentIsBrokenException
-     */
     public function testIncrementByNonInteger()
     {
+        $this->expectException(\Defuse\Crypto\Exception\EnvironmentIsBrokenException::class);
         \Defuse\Crypto\Core::incrementCounter(
             str_repeat("\x00", 16),
             1.0

--- a/test/unit/EncodingTest.php
+++ b/test/unit/EncodingTest.php
@@ -2,8 +2,9 @@
 
 use \Defuse\Crypto\Encoding;
 use \Defuse\Crypto\Core;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
-class EncodingTest extends PHPUnit_Framework_TestCase
+class EncodingTest extends TestCase
 {
     public function testEncodeDecodeEquivalency()
     {
@@ -46,10 +47,6 @@ class EncodingTest extends PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\BadFormatException
-     * @expectedExceptionMessage checksum doesn't match
-     */
     public function testIncorrectChecksum()
     {
         $header = Core::secureRandom(Core::HEADER_VERSION_SIZE);
@@ -65,13 +62,11 @@ class EncodingTest extends PHPUnit_Framework_TestCase
         $str[2*Encoding::SERIALIZE_HEADER_BYTES + 6] = 'f';
         $str[2*Encoding::SERIALIZE_HEADER_BYTES + 7] = 'f';
         $str[2*Encoding::SERIALIZE_HEADER_BYTES + 8] = 'f';
+        $this->expectException(\Defuse\Crypto\Exception\BadFormatException::class);
+        $this->expectExceptionMessage("checksum doesn't match");
         Encoding::loadBytesFromChecksummedAsciiSafeString($header, $str);
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\BadFormatException
-     * @expectedExceptionMessage not a hex string
-     */
     public function testBadHexEncoding()
     {
         $header = Core::secureRandom(Core::HEADER_VERSION_SIZE);
@@ -80,6 +75,8 @@ class EncodingTest extends PHPUnit_Framework_TestCase
             Core::secureRandom(Core::KEY_BYTE_SIZE)
         );
         $str[0] = 'Z';
+        $this->expectException(\Defuse\Crypto\Exception\BadFormatException::class);
+        $this->expectExceptionMessage('not a hex string');
         Encoding::loadBytesFromChecksummedAsciiSafeString($header, $str);
     }
 

--- a/test/unit/FileTest.php
+++ b/test/unit/FileTest.php
@@ -1,14 +1,15 @@
 <?php
 
 namespace Defuse\Crypto;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
-class FileTest extends \PHPUnit_Framework_TestCase
+class FileTest extends TestCase
 {
     private $key;
     private static $FILE_DIR;
     private static $TEMP_DIR;
 
-    public function setUp()
+    public function set_up()
     {
         self::$FILE_DIR = __DIR__ . '/File';
         self::$TEMP_DIR = self::$FILE_DIR . '/tmp';
@@ -19,7 +20,7 @@ class FileTest extends \PHPUnit_Framework_TestCase
         $this->key = Key::createNewRandomKey();
     }
 
-    public function tearDown()
+    public function tear_down()
     {
         array_map('unlink', glob(self::$TEMP_DIR . '/*'));
         rmdir(self::$TEMP_DIR);
@@ -149,29 +150,27 @@ class FileTest extends \PHPUnit_Framework_TestCase
             'Original file mismatches the result of encrypt and decrypt');
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
-     * @expectedExceptionMessage Input file is too small to have been created by this library.
-     */
     public function testDecryptBadMagicNumber()
     {
         $junk = self::$TEMP_DIR . '/junk';
         file_put_contents($junk, 'This file does not have the right magic number.');
+        $this->expectException(\Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException::class);
+        $this->expectExceptionMessage('Input file is too small to have been created by this library.');
         File::decryptFile($junk, self::$TEMP_DIR . '/unjunked', $this->key);
     }
 
     /**
      * @dataProvider garbageCiphertextProvider
-     * @expectedException \Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
      */
     public function testDecryptGarbage($ciphertext)
     {
         $junk = self::$TEMP_DIR . '/junk';
         file_put_contents($junk, $ciphertext);
+        $this->expectException(\Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException::class);
         File::decryptFile($junk, self::$TEMP_DIR . '/unjunked', $this->key);
     }
 
-    public function garbageCiphertextProvider()
+    public static function garbageCiphertextProvider()
     {
         $ciphertexts = [
             [str_repeat('this is not anything that can be decrypted.', 100)],
@@ -189,12 +188,10 @@ class FileTest extends \PHPUnit_Framework_TestCase
     {
         $junk = self::$TEMP_DIR . '/junk';
         file_put_contents($junk, '');
+        $this->expectException(\Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException::class);
         File::decryptFile($junk, self::$TEMP_DIR . '/unjunked', $this->key);
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
-     */
     public function testDecryptTruncatedCiphertext()
     {
         // This tests for issue #115 on GitHub.
@@ -209,6 +206,7 @@ class FileTest extends \PHPUnit_Framework_TestCase
         $truncated  = substr($ciphertext, 0, 64);
         file_put_contents($truncated_path, $truncated);
 
+        $this->expectException(\Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException::class);
         File::decryptFile($truncated_path, $plaintext_path, $this->key);
     }
 
@@ -243,10 +241,6 @@ class FileTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($plaintext, $plaintext_decrypted);
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
-     * @excpectedExceptionMessage Message Authentication failure; tampering detected.
-     */
     public function testExtraData()
     {
         $src  = self::$FILE_DIR . '/wat-gigantic-duck.jpg';
@@ -256,6 +250,8 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
         file_put_contents($dest, str_repeat('A', 2048), FILE_APPEND);
 
+        $this->expectException(\Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException::class);
+        $this->expectExceptionMessage('Integrity check failed.');
         File::decryptFile($dest, $dest . '.jpg', $this->key);
     }
 
@@ -265,122 +261,98 @@ class FileTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\Defuse\Crypto\Key', $result);
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\IOException
-     * @expectedExceptionMessage No such file or directory
-     */
     public function testBadSourcePathEncrypt()
     {
+        $this->expectException(\Defuse\Crypto\Exception\IOException::class);
+        $this->expectExceptionMessage('No such file or directory');
         File::encryptFile('./i-do-not-exist', 'output-file', $this->key);
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\IOException
-     * @expectedExceptionMessage No such file or directory
-     */
     public function testBadSourcePathDecrypt()
     {
+        $this->expectException(\Defuse\Crypto\Exception\IOException::class);
+        $this->expectExceptionMessage('No such file or directory');
         File::decryptFile('./i-do-not-exist', 'output-file', $this->key);
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\IOException
-     * @expectedExceptionMessage No such file or directory
-     */
     public function testBadSourcePathEncryptWithPassword()
     {
+        $this->expectException(\Defuse\Crypto\Exception\IOException::class);
+        $this->expectExceptionMessage('No such file or directory');
         File::encryptFileWithPassword('./i-do-not-exist', 'output-file', 'password');
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\IOException
-     * @expectedExceptionMessage No such file or directory
-     */
     public function testBadSourcePathDecryptWithPassword()
     {
+        $this->expectException(\Defuse\Crypto\Exception\IOException::class);
+        $this->expectExceptionMessage('No such file or directory');
         File::decryptFileWithPassword('./i-do-not-exist', 'output-file', 'password');
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\IOException
-     * @expectedExceptionMessage Is a directory
-     */
     public function testBadDestinationPathEncrypt()
     {
         $src  = self::$FILE_DIR . '/wat-gigantic-duck.jpg';
+        $this->expectException(\Defuse\Crypto\Exception\IOException::class);
+        $this->expectExceptionMessage('Is a directory');
         File::encryptFile($src, './', $this->key);
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\IOException
-     * @expectedExceptionMessage Is a directory
-     */
     public function testBadDestinationPathDecrypt()
     {
         $src  = self::$FILE_DIR . '/wat-gigantic-duck.jpg';
+        $this->expectException(\Defuse\Crypto\Exception\IOException::class);
+        $this->expectExceptionMessage('Is a directory');
         File::decryptFile($src, './', $this->key);
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\IOException
-     * @expectedExceptionMessage Is a directory
-     */
     public function testBadDestinationPathEncryptWithPassword()
     {
         $src  = self::$FILE_DIR . '/wat-gigantic-duck.jpg';
+        $this->expectException(\Defuse\Crypto\Exception\IOException::class);
+        $this->expectExceptionMessage('Is a directory');
         File::encryptFileWithPassword($src, './', 'password');
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\IOException
-     * @expectedExceptionMessage Is a directory
-     */
     public function testBadDestinationPathDecryptWithPassword()
     {
         $src  = self::$FILE_DIR . '/wat-gigantic-duck.jpg';
+        $this->expectException(\Defuse\Crypto\Exception\IOException::class);
+        $this->expectExceptionMessage('Is a directory');
         File::decryptFileWithPassword($src, './', 'password');
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\IOException
-     * @expectedExceptionMessage must be a resource
-     */
     public function testNonResourceInputEncrypt()
     {
         $resource = fopen('php://memory', 'wb');
+        $this->expectException(\Defuse\Crypto\Exception\IOException::class);
+        $this->expectExceptionMessage('must be a resource');
         File::encryptResource('not a resource', $resource, $this->key);
         fclose($resource);
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\IOException
-     * @expectedExceptionMessage must be a resource
-     */
     public function testNonResourceOutputEncrypt()
     {
         $resource = fopen('php://memory', 'wb');
+        $this->expectException(\Defuse\Crypto\Exception\IOException::class);
+        $this->expectExceptionMessage('must be a resource');
         File::encryptResource($resource, 'not a resource', $this->key);
         fclose($resource);
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\IOException
-     * @expectedExceptionMessage must be a resource
-     */
     public function testNonResourceInputDecrypt()
     {
         $resource = fopen('php://memory', 'wb');
+        $this->expectException(\Defuse\Crypto\Exception\IOException::class);
+        $this->expectExceptionMessage('must be a resource');
         File::decryptResource('not a resource', $resource, $this->key);
         fclose($resource);
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\IOException
-     * @expectedExceptionMessage must be a resource
-     */
     public function testNonResourceOutputDecrypt()
     {
         $resource = fopen('php://memory', 'wb');
+        $this->expectException(\Defuse\Crypto\Exception\IOException::class);
+        $this->expectExceptionMessage('must be a resource');
         File::decryptResource($resource, 'not a resource', $this->key);
         fclose($resource);
     }
@@ -396,14 +368,15 @@ class FileTest extends \PHPUnit_Framework_TestCase
         $output = fopen('php://memory', 'wb');
         try {
             File::decryptResource($stdin, $output, $this->key);
-        } catch (Exception $ex) {
+        } catch (\Exception $ex) {
             fclose($output);
             fclose($stdin);
+            $this->expectException(\Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException::class);
             throw $ex;
         }
     }
 
-    public function fileToFileProvider()
+    public static function fileToFileProvider()
     {
         $data = [];
 

--- a/test/unit/KeyTest.php
+++ b/test/unit/KeyTest.php
@@ -2,8 +2,9 @@
 
 use \Defuse\Crypto\Core;
 use \Defuse\Crypto\Key;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
-class KeyTest extends PHPUnit_Framework_TestCase
+class KeyTest extends TestCase
 {
     public function testCreateNewRandomKey()
     {
@@ -19,15 +20,13 @@ class KeyTest extends PHPUnit_Framework_TestCase
         $this->assertSame($key1->getRawBytes(), $key2->getRawBytes());
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\BadFormatException
-     * @excpectedExceptionMessage key version header
-     */
     public function testIncorrectHeader()
     {
         $key    = Key::createNewRandomKey();
         $str    = $key->saveToAsciiSafeString();
         $str[0] = 'f';
+        $this->expectException(\Defuse\Crypto\Exception\BadFormatException::class);
+        $this->expectExceptionMessage('Invalid header.');
         Key::loadFromAsciiSafeString($str);
     }
 }

--- a/test/unit/LegacyDecryptTest.php
+++ b/test/unit/LegacyDecryptTest.php
@@ -3,8 +3,9 @@
 use \Defuse\Crypto\Core;
 use \Defuse\Crypto\Crypto;
 use \Defuse\Crypto\Encoding;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
-class LegacyDecryptTest extends PHPUnit_Framework_TestCase
+class LegacyDecryptTest extends TestCase
 {
     public function testDecryptLegacyCiphertext()
     {
@@ -24,9 +25,6 @@ class LegacyDecryptTest extends PHPUnit_Framework_TestCase
         $this->assertSame($plain, 'This is a test message');
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
-     */
     public function testDecryptLegacyCiphertextWrongKey()
     {
         $cipher = Encoding::hexToBin(
@@ -37,6 +35,7 @@ class LegacyDecryptTest extends PHPUnit_Framework_TestCase
             '024b5e2009106870f1db25d8b85fd01f'
         );
 
+        $this->expectException(\Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException::class);
         $plain = Crypto::legacyDecrypt(
             $cipher,
             "\x01\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F"
@@ -44,13 +43,11 @@ class LegacyDecryptTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
-     * @expectedExceptionMessage short
-     */
     public function testLegacyDecryptTooShort()
     {
         $too_short = str_repeat("a", Core::LEGACY_MAC_BYTE_SIZE);
+        $this->expectException(\Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException::class);
+        $this->expectExceptionMessage('short');
         Crypto::legacyDecrypt($too_short, "0123456789ABCDEF");
     }
 

--- a/test/unit/PasswordTest.php
+++ b/test/unit/PasswordTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use \Defuse\Crypto\KeyProtectedByPassword;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
-class PasswordTest extends PHPUnit_Framework_TestCase
+class PasswordTest extends TestCase
 {
     public function testKeyProtectedByPasswordCorrect()
     {
@@ -15,12 +16,10 @@ class PasswordTest extends PHPUnit_Framework_TestCase
         $this->assertSame($key1->getRawBytes(), $key2->getRawBytes());
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
-     */
     public function testKeyProtectedByPasswordWrong()
     {
         $pkey = KeyProtectedByPassword::createRandomPasswordProtectedKey('rightpassword');
+        $this->expectException(\Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException::class);
         $key1 = $pkey->unlockKey('wrongpassword');
     }
 
@@ -47,19 +46,16 @@ class PasswordTest extends PHPUnit_Framework_TestCase
 
     /**
      * Check that changing the password actually changes the password.
-     * @expectedException \Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException
      */
     function testPasswordActuallyChanges()
     {
         $pkey1 = KeyProtectedByPassword::createRandomPasswordProtectedKey('password');
         $pkey1->changePassword('password', 'new password');
 
+        $this->expectException(\Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException::class);
         $pkey1->unlockKey('password');
     }
 
-    /**
-     * @expectedException \Defuse\Crypto\Exception\BadFormatException
-     */
     function testMalformedLoad()
     {
         $pkey1 = KeyProtectedByPassword::createRandomPasswordProtectedKey('password');
@@ -67,6 +63,7 @@ class PasswordTest extends PHPUnit_Framework_TestCase
 
         $pkey1_enc_ascii[0] = "\xFF";
 
+        $this->expectException(\Defuse\Crypto\Exception\BadFormatException::class);
         KeyProtectedByPassword::loadFromAsciiSafeString($pkey1_enc_ascii);
     }
 }

--- a/test/unit/RuntimeTestTest.php
+++ b/test/unit/RuntimeTestTest.php
@@ -1,11 +1,13 @@
 <?php
 
 use \Defuse\Crypto\RuntimeTests;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
-class RuntimeTestTest extends PHPUnit_Framework_TestCase
+class RuntimeTestTest extends TestCase
 {
     public function testRuntimeTest()
     {
+        $this->expectNotToPerformAssertions();
         RuntimeTests::runtimeTest();
     }
 }


### PR DESCRIPTION
Made PHPUnit tests pass in PHP 8.0, PHP 8.1 and PHP 8.2, by supporting PHPUnit 10, PHPUnit 8 and PHPUnit 5, complete with config files, one of which is explicitly picked by phpunit.sh based on the PHPUnit version previously determined based on the PHP version. This required dropping support for PHPUnit 4, but that is OK, as PHPUnit 5 still supports PHP 5.6, that being the earliest PHP version supported by this library.

Also fixed the broken exception message assertions in two of the tests, so that tests now pass.