### PR TITLE
composer.json: declare ext-hash dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "require": {
         "paragonie/random_compat": ">= 2",
         "ext-openssl": "*",
+        "ext-hash": "*",
         "php":  ">=5.6.0"
     },
     "require-dev": {


### PR DESCRIPTION
it seems its required for the package to work in https://github.com/defuse/php-encryption/blob/9b77beb6e1cd997aecfd2392849db5afab128b5e/src/Crypto.php#L282